### PR TITLE
fix: web service build points at the wrong Dockerfile path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     image: ghcr.io/duartesantos8/opengym-web:latest
     build:
       context: .
-      dockerfile: web/Dockerfile
+      dockerfile: Dockerfile
     restart: unless-stopped
     depends_on:
       media:


### PR DESCRIPTION
## Summary

\`docker-compose.yml\`'s \`web\` service builds with \`dockerfile: web/Dockerfile\`, but that file doesn't exist — \`web/\` only has \`nginx.conf\`. The actual multi-stage build (build the React app, then serve it with nginx) is at the repo root, and already \`COPY web/nginx.conf\` into the image. So the path in compose is just stale, and \`docker compose up --build\` fails immediately for anyone building from source instead of pulling the prebuilt \`ghcr.io\` images:

\`\`\`
failed to solve: failed to read dockerfile: open Dockerfile: no such file or directory
\`\`\`

## Fix

One line: \`dockerfile: web/Dockerfile\` → \`dockerfile: Dockerfile\` (the build \`context\` is already \`.\`, so this just points at the Dockerfile that's actually there).

## Test plan

Ran the full stack both ways with \`docker compose up -d --build\`:

- [x] Before the fix: build fails with the error above
- [x] After the fix: \`api\`, \`web\`, and \`media\` all build and start; \`GET /api/health\` → \`{"ok":true,...}\`; \`GET /\` → 200; exercise media served correctly